### PR TITLE
chore(inputs): update API base URL in action.yml and run.sh

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,8 +7,8 @@ branding:
 
 inputs:
   api_base_url:
-    description: "The base URL for API, e.g. 'https://unicode-api.luxass.dev' or 'https://preview.unicode-api.luxass.dev'"
-    default: "https://unicode-api.luxass.dev"
+    description: "The base URL for API, e.g. 'https://api.ucdjs.dev' or 'https://preview.api.ucdjs.dev'"
+    default: "https://api.ucdjs.dev"
   proxy_base_url:
     description: "The base URL for the proxy server, e.g. 'https://unicode-proxy.ucdjs.dev' or 'https://preview.unicode-proxy.ucdjs.dev'"
     default: "https://unicode-proxy.ucdjs.dev"

--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,15 @@ source "${SCRIPT_DIR}/utils.sh"
 # check for jq
 check_jq
 
-API_BASE_URL="${INPUT_API_BASE_URL:-"https://api.ucdjs.dev"}/api"
+if [[ -z "${INPUT_API_BASE_URL:-}" ]]; then
+  API_BASE_URL="https://api.ucdjs.dev/api"
+else
+  case "${INPUT_API_BASE_URL}" in
+    */api) API_BASE_URL="${INPUT_API_BASE_URL}" ;;
+    *)     API_BASE_URL="${INPUT_API_BASE_URL}/api" ;;
+  esac
+fi
+
 PROXY_BASE_URL="${INPUT_PROXY_BASE_URL:-"https://unicode-proxy.ucdjs.dev"}"
 
 info "🔍 checking for new releases"

--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,7 @@ source "${SCRIPT_DIR}/utils.sh"
 # check for jq
 check_jq
 
-API_BASE_URL="${INPUT_API_BASE_URL:-"https://unicode-api.luxass.dev"}/api"
+API_BASE_URL="${INPUT_API_BASE_URL:-"https://api.ucdjs.dev"}/api"
 PROXY_BASE_URL="${INPUT_PROXY_BASE_URL:-"https://unicode-proxy.ucdjs.dev"}"
 
 info "🔍 checking for new releases"


### PR DESCRIPTION
* Changed the default `api_base_url` to "https://api.ucdjs.dev" in both `action.yml` and `run.sh`.
* This ensures consistency in the API endpoint used across the GitHub Action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default API base URL and example URLs to use a new domain for Unicode data fetching.
  * Improved URL handling to ensure consistent API endpoint formatting without affecting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->